### PR TITLE
Include tree object when calling renderNode

### DIFF
--- a/dist/node.js
+++ b/dist/node.js
@@ -69,7 +69,7 @@ var Node = React.createClass({
         'div',
         { className: 'inner', ref: 'inner', onMouseDown: this.handleMouseDown },
         this.renderCollapse(),
-        tree.renderNode(index)
+        tree.renderNode(index, tree)
       ),
       this.renderChildren()
     );


### PR DESCRIPTION
This is the same change as my previous PR to fix this issue but under different folder (dist/ vs lib/)
I'm not sure why it was working before but got broken now