### PR TITLE
fixes alignment between leaf and branch nodes

### DIFF
--- a/dist/react-ui-tree.css
+++ b/dist/react-ui-tree.css
@@ -33,6 +33,10 @@
   position: relative;
   cursor: pointer;
   padding-left: 10px;
+  padding-top: 2px;
+}
+.m-node .inner .nrby-tree-collapse {
+  margin-left: -8px;
 }
 .m-node .collapse {
   position: absolute;

--- a/lib/react-ui-tree.less
+++ b/lib/react-ui-tree.less
@@ -31,6 +31,12 @@
     position: relative;
     cursor: pointer;
     padding-left: 10px;
+    padding-top: 2px;
+
+    .nrby-tree-collapse {
+      // 8px is the width of the caret
+      margin-left: -8px;
+    }
   }
 
   .collapse {


### PR DESCRIPTION
This fixes an issue where a leaf region context doesn't align correctly with a category region context because the 'caret' arrow takes up space.

 Before | After 
-- | --
![image](https://user-images.githubusercontent.com/19778393/70151554-c2023580-1679-11ea-9fea-b6f8e1ec6400.png) |  ![image](https://user-images.githubusercontent.com/19778393/70151640-d7775f80-1679-11ea-88ec-d1088a0da601.png)


