### PR TITLE
use event to get dom reference

### DIFF
--- a/dist/node.js
+++ b/dist/node.js
@@ -83,7 +83,7 @@ var Node = (0, _createReactClass2.default)({
       { className: cssClasses },
       _react2.default.createElement(
         'div',
-        { className: 'inner', ref: 'inner', onMouseDown: this.handleMouseDown },
+        { className: 'inner', onMouseDown: this.handleMouseDown },
         this.renderCollapse(),
         tree.renderNode(index, tree)
       ),
@@ -102,12 +102,10 @@ var Node = (0, _createReactClass2.default)({
     var _props4 = this.props,
         index = _props4.index,
         onDragStart = _props4.onDragStart;
-    // TODO: shouldn't be handling refs like this
 
-    var dom = this.refs.inner;
 
     if (onDragStart && !window.dragMode) {
-      onDragStart(index.id, dom, e);
+      onDragStart(index.id, e.target, e);
     }
   }
 });

--- a/lib/node.js
+++ b/lib/node.js
@@ -62,7 +62,7 @@ var Node = createClass({
 
     return (
       <div className={cssClasses}>
-        <div className="inner" ref="inner" onMouseDown={this.handleMouseDown}>
+        <div className="inner" onMouseDown={this.handleMouseDown}>
           {this.renderCollapse()}
           {tree.renderNode(index, tree)}
         </div>
@@ -79,11 +79,9 @@ var Node = createClass({
 
   handleMouseDown(e) {
     const { index, onDragStart } = this.props;
-    // TODO: shouldn't be handling refs like this
-    let dom = this.refs.inner;
 
     if(onDragStart && !window.dragMode) {
-      onDragStart(index.id, dom, e);
+      onDragStart(index.id, e.target, e);
     }
   }
 });


### PR DESCRIPTION
This pull removes the use of legacy string refs to get a reference to the dom node by using the dom  reference found in the event.